### PR TITLE
python implementation, explictly released into the public domain

### DIFF
--- a/implementations/python/unwrap.py
+++ b/implementations/python/unwrap.py
@@ -1,0 +1,56 @@
+#!/bin/env python3
+
+# This version was ported by Tristan Havelick, 2021
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+# 
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+# 
+# For more information, please refer to <https://unlicense.org>
+
+import fileinput
+import re
+
+def early_indent(line, next_line):
+    words = next_line.split(' ')
+    return (len(line + ' ' + words[0]) < len(next_line))
+
+result = []
+line = ''
+previous_line = ''
+sentinel = False
+for line in fileinput.input():    
+    line = line.rstrip()
+    if sentinel:
+        if (
+            line == '' or 
+            previous_line == '' or
+            re.match(r'^[^A-Za-z0-9]', line) or
+            early_indent(previous_line, line)
+        ):
+            result.extend([previous_line, "\n"])
+        else:
+            result.extend([previous_line, ' '])
+    previous_line = line
+    sentinel = True
+result.append(line)
+print(''.join(result))


### PR DESCRIPTION
I bet you didn't expect to see a pull request for something you wrote 10 years ago!

# What is this?

I've written a python port of your unwrap code and thought I'd try to add it back to your repo for anyone else that might find it useful.

# Why
(you don't really need to read this part if you're busy) 

I'm working on a project for which the goal is to create a program that can convert arbitrary text files intended for display on fixed-width terminals to Markdown. The idea being that it can then be taken from that format and converted into HTML, epub or whatever is needed for easier reading on variable width devices like phones or e-readers.

Unfolding or unwrapping fixed width text is an important piece of this and your algorithm was simple and very comprehensible and a perfect fit for this part of my project.

Thank you so much for putting this together and writing up the accompanying blog post!

# Licensing
Since your original code did not have a license, I'm assuming it to be public domain.  I'm explicitly releasing the python version under the [unlicense ](https://choosealicense.com/licenses/unlicense/). I'm happy to remove the header on my code if you'd like to add a license to the project as a whole. I'm cool with my implementation under any open license including MIT, GPL or just public domain. 

# Implementation differences
It seems like I uncovered a couple bugs in the perl version
## Missing final line
It seems the perl version has a a bug in which the final line of the original text isn't appended to the final line of the output. This can be seen by running the following on a clean `master`:

```
implementations/perl/unwrap.pl example/example.txt > example/output.txt
git diff example/output.txt
```
You'll see the output is missing the final words, "length will be retained".

This is fixed in the python version.

## Doubled spaces
It seems that if the original content has trailing spaces, those spaces extra spaces will show up between words when condensed into a single line. In the python version

I just trim whitespace from the right side of each line to avoid this. 


